### PR TITLE
Restructure to mime GNU cat behaviour

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,37 +10,55 @@ use nix::unistd::pipe;
 
 const BUF_SIZE: usize = 16384;
 
+#[inline]
+fn cat<T: AsRawFd>(input: &T) {
+    let (rd, wr) = pipe().unwrap();
+    let stdout = io::stdout();
+    let _handle = stdout.lock();
+
+    loop {
+        let res = splice(
+            input.as_raw_fd(),
+            None,
+            wr,
+            None,
+            BUF_SIZE,
+            SpliceFFlags::empty(),
+        ).unwrap();
+
+        if res == 0 {
+            // We read 0 bytes from the input,
+            // which means we're done copying.
+            break;
+        }
+
+        let _res = splice(
+            rd,
+            None,
+            stdout.as_raw_fd(),
+            None,
+            BUF_SIZE,
+            SpliceFFlags::empty(),
+        ).unwrap();
+    }
+}
+
 fn main() {
-    for path in env::args().skip(1) {
-        let input = File::open(&path).expect(&format!("fcat: {}: No such file or directory", path));
-        let (rd, wr) = pipe().unwrap();
-        let stdout = io::stdout();
-        let _handle = stdout.lock();
-
-        loop {
-            let res = splice(
-                input.as_raw_fd(),
-                None,
-                wr,
-                None,
-                BUF_SIZE,
-                SpliceFFlags::empty(),
-            ).unwrap();
-
-            if res == 0 {
-                // We read 0 bytes from the input,
-                // which means we're done copying.
-                break;
-            }
-
-            let _res = splice(
-                rd,
-                None,
-                stdout.as_raw_fd(),
-                None,
-                BUF_SIZE,
-                SpliceFFlags::empty(),
-            ).unwrap();
+    let args: Vec<_> = env::args().skip(1).collect();
+    if args.is_empty() {
+        let stdin = io::stdin();
+        let _handle = stdin.lock();
+        cat(&stdin);
+    } else {
+        for path in env::args().skip(1) {
+            if path == "-" {
+                let stdin = io::stdin();
+                let _handle = stdin.lock();
+                cat(&stdin);
+            } else {
+                cat(&File::open(&path)
+                    .expect(&format!("fcat: {}: No such file or directory", path)))
+            };
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
         let _handle = stdin.lock();
         cat(&stdin);
     } else {
-        for path in env::args().skip(1) {
+        for path in args.into_iter() {
             if path == "-" {
                 let stdin = io::stdin();
                 let _handle = stdin.lock();


### PR DESCRIPTION
Passing no parameters or the parameter `-` to `cat` should read from
stdin.

For fun and profit!