### PR TITLE
[WIP] Prevent issues due to caching in the compiler, when building the docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apt update \
 
 # create a new empty shell project
 RUN USER=root cargo new --bin fcat
+WORKDIR /fcat
 # set modification date in the past so the actual source files will be compiled
 RUN touch -t 197001010000 src/main.rs
-WORKDIR /fcat
 
 # copy over your manifests
 COPY ./Cargo.lock Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt update \
 
 # create a new empty shell project
 RUN USER=root cargo new --bin fcat
+# set modification date in the past so the actual source files will be compiled
+RUN touch -t 197001010000 src/main.rs
 WORKDIR /fcat
 
 # copy over your manifests


### PR DESCRIPTION
The `Dockerfile` uses Docker layers to cache the build dependencies. This only works if the initial image is built before the last modification to the `main.rs` file, since the Rust compiler will only rebuild a file, if the last modified date (now) is higher than the last time the code was built.
The repository that should cache the build dependencies will be created after the last modification of the actual `main.rs` file.
To fix this, I change the modification date of the `main.rs` inside the container to `1970-01-01`.
While this _should_ work, I am not able to test it currently.