### PR TITLE
Implement multi-stage build process for the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY ./Cargo.toml Cargo.toml
 
 # this build step will cache your dependencies
 RUN cargo build --release
-# remove cached build artefact to prevent caching issues
+# remove cached build artifact to prevent caching issues
 RUN rm target/x86_64-unknown-linux-musl/release/fcat
 
 # copy & build source files

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,18 @@ FROM ekidd/rust-musl-builder:1.27.2 as builder
 # create a new empty shell project
 RUN USER=rust cargo new --bin fcat
 WORKDIR /home/rust/src/fcat
-# set modification date in the past so the actual source files will be compiled
-RUN touch -t 197001010000 src/main.rs
 
 # copy over your manifests
 COPY ./Cargo.lock Cargo.lock
 COPY ./Cargo.toml Cargo.toml
 
 # this build step will cache your dependencies
+RUN cargo build --release
+# remove cached build artefact to prevent caching issues
+RUN rm target/x86_64-unknown-linux-musl/release/fcat
+
+# copy & build source files
+COPY src/ src/
 RUN cargo build --release
 
 FROM alpine:latest

--- a/entrypoint
+++ b/entrypoint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 RAMDISK=/media/ramdisk
 INPUT_FILE=kitty


### PR DESCRIPTION
Multi-stage builds help producing smaller image sizes. This setup uses
the `ekidd/rust-musl-builder` image to compile the source code and
executes the benchmark in an Alpine Linux image.

The old `Dockerfile` produced an `1.81GB` image while the resulting
image using the new `Dockerfile` is only `10.1MB`.

(As discussed in #14)